### PR TITLE
Better regex

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@ helga-pull-requests
 ===================
 
 A helga plugin to quickly link to github pull requests. This will match either the pattern
-<repo_name>-pr<number> (when PULL_REQUESTS_DEFAULT_ACCOUNT is set) or <account>/<repo_name>-pr<number>.
+<repo_name>-pr<number> (when PULL_REQUESTS_DEFAULT_ACCOUNT is set) or <account>/<repo_name>-pr<number> or <account>/<repo_name>/pull/<number>.
 
 Settings
 --------

--- a/helga_pull_requests.py
+++ b/helga_pull_requests.py
@@ -2,6 +2,8 @@ from helga import settings
 from helga.plugins import match
 
 
+@match(r'\s(([\w\-\.]+?)/)?([\w\-\.]+?)/pull/([\d]+)')
+@match(r'^(([\w\-\.]+?)/)?([\w\-\.]+?)/pull/([\d]+)')
 @match(r'(([\w\-\.]+?)/)?([\w\-\.]+?)-pr([\d]+)')
 def pull_requests(client, channel, nick, message, matches):
     prs = []

--- a/test_helga_pull_requests.py
+++ b/test_helga_pull_requests.py
@@ -75,3 +75,21 @@ def test_match_regex():
 
     for repo, expected in expectations.iteritems():
         assert re.findall(plugin_cls.pattern, repo)[0] == expected
+
+
+def test_extended_regex():
+    plugin_cls = pull_requests._plugins[1]
+    msg = 'shaunduncan/helga-pull-requests/pull/2'
+    res = ('shaunduncan/', 'shaunduncan', 'helga-pull-requests', '2')
+    assert re.findall(plugin_cls.pattern, msg)[0] == res
+
+    msg = 'https://github.com/shaunduncan/helga-pull-requests/pull/2'
+    assert re.findall(plugin_cls.pattern, msg) == []
+
+    plugin_cls = pull_requests._plugins[2]
+    msg = 'this is a test shaunduncan/helga-pull-requests/pull/2'
+    res = ('shaunduncan/', 'shaunduncan', 'helga-pull-requests', '2')
+    assert re.findall(plugin_cls.pattern, msg)[0] == res
+
+    msg = 'this is a test https://github.com/shaunduncan/helga-pull-requests/pull/2'
+    assert re.findall(plugin_cls.pattern, msg) == []


### PR DESCRIPTION
The two new matches are intended to catch:
"here is some possible text `shaunduncan/helga-pull-requests/pull/2`"
and:
"`shaunduncan/helga-pull-requests/pull/2` here is some possible text"
but not any form of:
"`http://github.com/shaunduncan/helga-pull-requests/pull/2`"
with text before, after, or by itself
